### PR TITLE
Decrease run time by enabling parallelization

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ article.
 `mixemt` is written in Python and requires a few additional packages:
 
 * [NumPy/SciPy](http://scipy.org/)
+* [Numba](http://numba.pydata.org/)
 * [Biopython](http://biopython.org/)
 * [pysam](https://github.com/pysam-developers/pysam)
 
@@ -107,6 +108,14 @@ Reconstructed Sapiens Reference Sequence (RSRS) contained in
 #### `--phy phylotree.csv`
 Specify a Phylotree CSV file to use. By default, the file for Phylotree
 Build 17 (`mixemt/phylotree/mtDNA_tree_Build_17.csv`) is used.
+
+#### `--no-parallel`
+Disable the parallel execution of code. Parallelization is used to build the
+EM matrix and performing the expectation-maximization steps. 
+
+#### `--threads`
+Specify the number of threads that should be used for steps that can be
+parallelized. By default, all threads available on the machine are used.
 
 ### Customization options
 

--- a/bin/mixemt
+++ b/bin/mixemt
@@ -361,6 +361,8 @@ def main():
     parser.add_argument("--phy", dest="phy_fn",
                         metavar="phylotree.csv", type=str, default=None,
                         help="Phylotree CSV file (Default: Build 17).")
+    parser.add_argument("--threads", dest="threads", type=int, default=None,
+                        help="specify the number of threads to use [all]")
 
     cust_opts = parser.add_argument_group("customization options")
     cust_opts.add_argument('-H', '--haps', dest='cust_hap_fn', type=str,

--- a/bin/mixemt
+++ b/bin/mixemt
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python3
 """
 
 mixemt (Mix + EM + mitochondrial sequence)
@@ -361,8 +361,11 @@ def main():
     parser.add_argument("--phy", dest="phy_fn",
                         metavar="phylotree.csv", type=str, default=None,
                         help="Phylotree CSV file (Default: Build 17).")
+    parser.add_argument("--no-parallel", dest="parallel",
+                        action="store_false", default=True,
+                        help="disable parallel execution")
     parser.add_argument("--threads", dest="threads", type=int, default=None,
-                        help="specify the number of threads to use [all]")
+                        help="specify the number of threads to use in parallel mode [all]")
 
     cust_opts = parser.add_argument_group("customization options")
     cust_opts.add_argument('-H', '--haps', dest='cust_hap_fn', type=str,

--- a/bin/mixemt
+++ b/bin/mixemt
@@ -233,7 +233,7 @@ def dump_all(prefix, haps, reads, em_mat, em_results):
             for hap in haps:
                 hap_out.write('%s\n' % (hap))
         with open("%s.reads" % (prefix), 'w') as read_out:
-            for i in xrange(len(reads)):
+            for i in range(len(reads)):
                 read_out.write('%d\t%s\n' % (i, '\t'.join(reads[i])))
         props, read_hap_mat = em_results
         numpy.save("%s.em" % (prefix), em_mat)

--- a/mixemt/em.py
+++ b/mixemt/em.py
@@ -35,7 +35,7 @@ def nb_logsumexp_axis1(X):
         c = 0.0
         for x in X[:, i]:
             c += numpy.exp(x - xmax[i])
-        res[i] = numpy.log(c)
+        res[i] = numpy.log(c) + xmax[i]
     return res
 
 @nb.jit(nopython=True, parallel=True)
@@ -50,7 +50,7 @@ def nb_logsumexp_axis0_weights(X, b):
         r = 0.0
         for x in X[i, :]:
             r += numpy.exp(x - xmax[i])
-        res[i] = numpy.log(b[i] * r)
+        res[i] = numpy.log(b[i] * r) + xmax[i]
     return res
 
 

--- a/mixemt/em.py
+++ b/mixemt/em.py
@@ -35,7 +35,7 @@ def nb_logsumexp_axis1(X):
         c = 0.0
         for x in X_xmax[i, :]:
             c += numpy.exp(x)
-        res[i] = numpy.log(c) 
+        res[i] = numpy.log(c)
     res += xmax
     return res
 

--- a/mixemt/em.py
+++ b/mixemt/em.py
@@ -31,7 +31,7 @@ def nb_logsumexp_axis1(X):
     for i in nb.prange(X.shape[0]):
         xmax[i] = numpy.max(X[i, :])
     xmax[~numpy.isfinite(xmax)] = 0
-    X -= xmax.reshape((-1, 1))
+    X -= xmax.reshape(-1, 1)
     res = numpy.empty(X.shape[0], dtype=X.dtype)
     for i in nb.prange(X.shape[0]):
         c = 0.0
@@ -39,6 +39,7 @@ def nb_logsumexp_axis1(X):
             c += numpy.exp(x)
         res[i] = numpy.log(c) 
     return res + xmax
+
 
 @nb.jit(nopython=True, parallel=True)
 def nb_logsumexp_axis0_weights(X, b):

--- a/mixemt/em.py
+++ b/mixemt/em.py
@@ -145,7 +145,9 @@ def run_em(read_hap_mat, weights, args):
                       matrix (log)
     """
     # Specify the number of parallel threads
-    if args.threads is not None:
+    if not args.parallel:
+        nb.set_num_threads(1)
+    elif args.threads is not None:
         nb.set_num_threads(args.threads)
 
     # arrays for new calculations

--- a/mixemt/phylotree.py
+++ b/mixemt/phylotree.py
@@ -446,15 +446,15 @@ def example():
     #       /   F     G
     #      /   / \   / \
     #     A   B   C D   E
-    phy_in = ['I, A1G ,,',
-              ',H, A3T A5T ,,',
-              ',,F, A6T ,,',
-              ',,,B, A8T ,,',
-              ',,,C, T5A ,,',
-              ',,G, A7T ,,',
-              ',,,D, A9T ,,',
-              ',,,E, A4T ,,',
-              ',A, A2T A4T ,,']
+    phy_in = [b'I, A1G ,,',
+              b',H, A3T A5T ,,',
+              b',,F, A6T ,,',
+              b',,,B, A8T ,,',
+              b',,,C, T5A ,,',
+              b',,G, A7T ,,',
+              b',,,D, A9T ,,',
+              b',,,E, A4T ,,',
+              b',A, A2T A4T ,,']
     return Phylotree(phy_in)
 
 

--- a/mixemt/preprocess.py
+++ b/mixemt/preprocess.py
@@ -15,15 +15,15 @@ Wed Apr  6 10:48:21 PDT 2016
 import sys
 import math
 import collections
-import numpy
 import itertools
-import numba
 from multiprocessing import Pool, sharedctypes
+import numpy
+import numba as nb
 
 from mixemt import phylotree
 
 
-class HapVarBaseMatrix(object):
+class HapVarBaseMatrix():
     """
     This class is designed to simplify a pretty large 3 dimensional matrix of
     indicator variables. Since our matrix is sparse and only need to look up
@@ -54,7 +54,6 @@ class HapVarBaseMatrix(object):
                                      * sum(self.phylo.variants[pos].values()))
 
         self.add_hap_markers(phylo.hap_var)
-        return
 
     def add_hap_markers(self, hap_var):
         """
@@ -67,7 +66,6 @@ class HapVarBaseMatrix(object):
                 der = phylotree.der_allele(var)
                 if der != self.refseq[pos]:
                     self.markers[hap][pos] = der
-        return
 
     def _prob(self, hap_pos, pos, base):
         """
@@ -209,12 +207,13 @@ def build_em_matrix(refseq, phylo, reads, haplogroups, args):
 
         mat_idxs = [(i, j) for i, j in
                     itertools.product(range(0, len(reads)),
-                                    range(0, len(haplogroups)))]
+                                      range(0, len(haplogroups)))]
 
         if args.threads is None:
             args.threads = nb.config.NUMBA_DEFAULT_NUM_THREADS
 
-        with Pool(initializer=init_subprocess, initargs=(hvb_mat, haplogroups, reads, shared_array,),
+        with Pool(initializer=init_subprocess,
+                  initargs=(hvb_mat, haplogroups, reads, shared_array,),
                   processes=args.threads) as p:
             res = p.map(fill_mat, mat_idxs, 5408)
         read_hap_mat = numpy.ctypeslib.as_array(shared_array)

--- a/mixemt/preprocess.py
+++ b/mixemt/preprocess.py
@@ -215,7 +215,7 @@ def build_em_matrix(refseq, phylo, reads, haplogroups, args):
         with Pool(initializer=init_subprocess,
                   initargs=(hvb_mat, haplogroups, reads, shared_array,),
                   processes=args.threads) as p:
-            res = p.map(fill_mat, mat_idxs, 5408)
+            res = p.map(fill_mat, mat_idxs, len(haplogroups))
         read_hap_mat = numpy.ctypeslib.as_array(shared_array)
     else:  # Use only a single core
         read_hap_mat = numpy.empty((len(reads), len(haplogroups)))

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ setup(
                              'phylotree/mtDNA_tree_Build_17.csv',
                              'ref/README.txt', 'phylotree/README.md']},
     scripts=['bin/mixemt'],
-    install_requires=['numpy', 'scipy', 'pysam', 'biopython']
+    install_requires=['numpy', 'scipy', 'pysam', 'biopython', 'numba', 'ttd']
     )


### PR DESCRIPTION
Add option to parallelise two time-consuming steps:

initial building of the EM matrix from the read profile (build_em_matrix) by using the map function of the module multiprocessing and operating on a shared-memory Numpy array
the single iteration of the EM algorithm (em_step) by implementing the logsumexp function from Scipy into a parallel Numba function

Parallelization is activated by default, using all available threads of the machine. Using commandline options the number of threads can be specified or parallelisation can be switched off returning to the initial implementation as the fallback option.